### PR TITLE
build image on workflow dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: Build Docker Image
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -19,8 +20,13 @@ jobs:
       - name: Tag Info
         id: tag_info
         run: |
-          export IMAGE_TAG="${GITHUB_REF#refs/*/}"
-          export IMAGE_TAG=${IMAGE_TAG//[^[:alnum:].-]/-}
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            export IMAGE_TAG=$(git rev-parse --short HEAD)
+          else
+            export IMAGE_TAG="${GITHUB_REF#refs/*/}"
+            export IMAGE_TAG=${IMAGE_TAG//[^[:alnum:].-]/-}
+          fi
+          echo "Image Tag: ${IMAGE_TAG}"
           echo ::set-output name=IMAGE_TAG::${IMAGE_TAG}
 
       - name: Configure AWS credentials

--- a/tests/test_who.py
+++ b/tests/test_who.py
@@ -22,6 +22,7 @@ from who import (
     get_indicators_and_tags,
     get_showcase,
 )
+from hdx.data.showcase import Showcase
 
 
 class MockRetrieve:
@@ -475,4 +476,4 @@ class TestWHO:
                     "who-data-for-afghanistan",
                     ["hxl", "indicators"],
                 )
-                assert showcase is None
+                assert showcase == Showcase({"name": "who-data-for-afghanistan-showcase"})


### PR DESCRIPTION
@mcarans do you see any issue with this? I'd like to be able to build docker images on any branch and tag with the commit hash, to test in jenkins (on stage obviously) 

I also fixed the tests in this PR