### PR TITLE
HDXDSYS-604 change name to iso3 in urls

### DIFF
--- a/run.py
+++ b/run.py
@@ -39,7 +39,7 @@ def main(
     save: bool = False,
     use_saved: bool = False,
     populate_db: bool = True,
-    create_archived_datasets: bool = True,
+    create_archived_datasets: bool = False,
 ) -> None:
     """Generate datasets and create them in HDX
 

--- a/tests/test_who.py
+++ b/tests/test_who.py
@@ -568,7 +568,7 @@ class TestWHO:
                 "dataset_date": "[2005-01-01T00:00:00 TO 2019-12-31T23:59:59]",
                 "groups": [{"name": "afg"}],
                 "maintainer": "35f7bb2c-4ab6-4796-8334-525b30a94c89",
-                "name": "who-data-for-afghanistan",
+                "name": "who-data-for-afg",
                 "notes": "This dataset contains data from WHO's [data "
                 "portal](https://www.who.int/gho/en/) covering the following "
                 "categories:  \n"
@@ -643,7 +643,7 @@ class TestWHO:
 
             assert showcase == {
                 "image_url": "https://cdn.who.int/media/images/default-source/countries-overview/flags/afg.jpg",
-                "name": "who-data-for-afghanistan-showcase",
+                "name": "who-data-for-afg-showcase",
                 "notes": "Health indicators for Afghanistan",
                 "tags": [
                     {
@@ -695,12 +695,12 @@ class TestWHO:
                     retriever,
                     "AFG",
                     "Afghanistan",
-                    "who-data-for-afghanistan",
+                    "who-data-for-afg",
                     ["hxl", "indicators"],
                 )
                 assert showcase == {
                     "image_url": "https://cdn.who.int/media/images/default-source/countries-overview/flags/afg.jpg",
-                    "name": "who-data-for-afghanistan-showcase",
+                    "name": "who-data-for-afg-showcase",
                     "notes": "Health indicators for Afghanistan",
                     "tags": [
                         {
@@ -719,12 +719,10 @@ class TestWHO:
                     retriever,
                     "ABC",
                     "Afghanistan",
-                    "who-data-for-afghanistan",
+                    "who-data-for-afg",
                     ["hxl", "indicators"],
                 )
-                assert showcase == {
-                    "name": "who-data-for-afghanistan-showcase"
-                }
+                assert showcase == {"name": "who-data-for-afg-showcase"}
 
     def test_showcase_for_nonexistent_url(self, configuration):
         with temp_dir(
@@ -745,11 +743,11 @@ class TestWHO:
                     retriever,
                     "ABC",
                     "Afghanistan",
-                    "who-data-for-afghanistan",
+                    "who-data-for-afg",
                     ["hxl", "indicators"],
                 )
                 assert showcase == Showcase(
-                    {"name": "who-data-for-afghanistan-showcase"}
+                    {"name": "who-data-for-afg-showcase"}
                 )
 
     def test_generate_archived_dataset(

--- a/who.py
+++ b/who.py
@@ -334,7 +334,7 @@ class WHO:
         title = f"{country_name} - Health Indicators"
 
         logger.info(f"Creating dataset: {title}")
-        slugified_name = slugify(f"WHO data for {country_name}").lower()
+        slugified_name = slugify(f"WHO data for {country_iso3}").lower()
 
         # Get unique category names
 


### PR DESCRIPTION
The same change as PR #13 but for the new API. I've done both depending on when the migration happens, before or after deploying the new pipeline. 